### PR TITLE
Bugfix for index_fieldname argument which didn't have behaviour mentioned in the doc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -91,3 +91,4 @@ Thanks to
       fields with Whoosh as long as they share a consistent sort direction
     * Steven Skoczen (@skoczen) for an ElasticSearch bug fix
     * @Xaroth for updating the app loader to be compatible with Django 1.7
+    * Jaroslav Gorjatsev (jarig) for a bugfix with index_fieldname

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -377,9 +377,13 @@ class SolrSearchBackend(BaseSearchBackend):
             model = get_model(app_label, model_name)
 
             if model and model in indexed_models:
+                index = unified_index.get_index(model)
+                index_field_map = index.field_map
                 for key, value in raw_result.items():
-                    index = unified_index.get_index(model)
                     string_key = str(key)
+                    # re-map key if alternate name used
+                    if string_key in index_field_map:
+                        string_key = index_field_map[key]
 
                     if string_key in index.fields and hasattr(index.fields[string_key], 'convert'):
                         additional_fields[string_key] = index.fields[string_key].convert(value)

--- a/haystack/indexes.py
+++ b/haystack/indexes.py
@@ -105,7 +105,10 @@ class SearchIndex(with_metaclass(DeclarativeMetaclass, threading.local)):
         self.prepared_data = None
         content_fields = []
 
+        self.field_map = dict()
         for field_name, field in self.fields.items():
+            #form field map
+            self.field_map[field.index_fieldname] = field_name
             if field.document is True:
                 content_fields.append(field_name)
 

--- a/test_haystack/solr_tests/test_solr_backend.py
+++ b/test_haystack/solr_tests/test_solr_backend.py
@@ -49,6 +49,19 @@ class SolrMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
         return MockModel
 
 
+class SolrMockOverriddenFieldNameSearchIndex(indexes.SearchIndex, indexes.Indexable):
+    text = indexes.CharField(document=True, use_template=True)
+    name = indexes.CharField(model_attr='author', faceted=True, index_fieldname='name_s')
+    pub_date = indexes.DateField(model_attr='pub_date', index_fieldname='pub_date_dt')
+    today = indexes.IntegerField(index_fieldname='today_i')
+
+    def prepare_today(self, obj):
+        return datetime.datetime.now().day
+
+    def get_model(self):
+        return MockModel
+
+
 class SolrMaintainTypeMockSearchIndex(indexes.SearchIndex, indexes.Indexable):
     text = indexes.CharField(document=True, use_template=True)
     month = indexes.CharField(indexed=False)
@@ -187,6 +200,7 @@ class SolrSearchBackendTestCase(TestCase):
         self.ui = UnifiedIndex()
         self.smmi = SolrMockSearchIndex()
         self.smtmmi = SolrMaintainTypeMockSearchIndex()
+        self.smofnmi = SolrMockOverriddenFieldNameSearchIndex()
         self.ui.build(indexes=[self.smmi])
         connections['solr']._index = self.ui
         self.sb = connections['solr'].get_backend()
@@ -321,6 +335,24 @@ class SolrSearchBackendTestCase(TestCase):
 
         self.sb.clear([AnotherMockModel, MockModel])
         self.assertEqual(self.raw_solr.search('*:*').hits, 0)
+
+    def test_atlernate_index_fieldname(self):
+        self.ui.build(indexes=[self.smofnmi])
+        connections['solr']._index = self.ui
+        self.sb.update(self.smofnmi, self.sample_objs)
+        search = self.sb.search('*')
+        self.assertEqual(search['hits'], 3)
+        results = search['results']
+        today = datetime.datetime.now().day
+        self.assertEqual([result.today for result in results], [today, today, today])
+        self.assertEqual([result.name for result in results], ['daniel1', 'daniel2', 'daniel3'])
+        self.assertEqual([result.pub_date for result in results], [datetime.date(2009, 2, 25) - datetime.timedelta(days=1),
+                                                                   datetime.date(2009, 2, 25) - datetime.timedelta(days=2),
+                                                                   datetime.date(2009, 2, 25) - datetime.timedelta(days=3)])
+        # revert it back
+        self.ui.build(indexes=[self.smmi])
+        connections['solr']._index = self.ui
+
 
     def test_search(self):
         self.sb.update(self.smmi, self.sample_objs)


### PR DESCRIPTION
From doc:
> "The index_fieldname option allows you to force the name of the field in the index. This does not change how Haystack refers to the field. This is useful when using Solr’s dynamic attributes or when integrating with other external software.
Default is variable name of the field within the SearchIndex."

However, once index_fieldname is set it was possible to refer to the related field only using its value, but not declared in an index class field name.
This patch fixes this behavior, so that index_fieldname will affect only how indexed field is stored in a backend, while it will be possible to refer to it using declared in the index class field name.