### PR TITLE
Generic Views

### DIFF
--- a/haystack/views.py
+++ b/haystack/views.py
@@ -87,7 +87,7 @@ class SearchMixin(MultipleObjectMixin):
         if self.results and hasattr(self.results, 'query') and self.results.query.backend.include_spelling:
             context['suggestion'] = self.form.get_suggestion()
         context['page'] = context['page_obj'] # for backward compatibility
-        return self.context_class(context)
+        return context
 
     # Depricated methods and properties for backward compatibility
 


### PR DESCRIPTION
I've converted views to the django's generic views mixin style, which brings great advantages:
* views are now consistent with django style
* can be customized easily without completely overriding View classes
* mixin is possible with already existing Generic Views in other apps
* different Paginator class can be specified without even creating a new View class (by passing as a kwarg)
* completely backward compatible (maybe except unused method build_page and context_class property)