### PR TITLE
Convert distance object to string for elasticsearch

### DIFF
--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -439,7 +439,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             lng, lat = dwithin['point'].get_coords()
             dwithin_filter = {
                 "geo_distance": {
-                    "distance": dwithin['distance'].km,
+                    "distance": '%s meters' % dwithin['distance'].m,
                     dwithin['field']: {
                         "lat": lat,
                         "lon": lng
@@ -706,12 +706,12 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 #            the right type of storage?
 DEFAULT_FIELD_MAPPING = {'type': 'string', 'analyzer': 'snowball'}
 FIELD_MAPPINGS = {
-    'edge_ngram': {'type': 'string', 'analyzer': 'edgengram_analyzer'},        
-    'ngram':      {'type': 'string', 'analyzer': 'ngram_analyzer'},        
+    'edge_ngram': {'type': 'string', 'analyzer': 'edgengram_analyzer'},
+    'ngram':      {'type': 'string', 'analyzer': 'ngram_analyzer'},
     'date':       {'type': 'date'},
     'datetime':   {'type': 'date'},
 
-    'location':   {'type': 'geo_point'},        
+    'location':   {'type': 'geo_point'},
     'boolean':    {'type': 'boolean'},
     'float':      {'type': 'float'},
     'long':       {'type': 'long'},


### PR DESCRIPTION
After upgrading to ElasticSearch 1.0, `geo_distance` searches broke. Apparently the default unit the geo queries changed to meters:

http://www.elasticsearch.org/guide/en/elasticsearch/reference/master/_parameters.html

To maintain backwards compatibility with 0.90.x we can convert the distance object to a string with an explicit unit.