### PR TITLE
Support elasticsearch 1.x.x distance filter syntax

### DIFF
--- a/docs/running_tests.rst
+++ b/docs/running_tests.rst
@@ -41,6 +41,13 @@ list of possible options::
 
 .. _nose: https://nose.readthedocs.org/en/latest/
 
+Or, to run the Elasticsearch backend's tests::
+
+    cd django-haystack/tests
+    export PYTHONPATH=`pwd`/..:`pwd`
+    export GEOS_LIBRARY_PATH=/opt/boxen/homebrew/lib/libgeos_c.dylib
+    export GDAL_LIBRARY_PATH=/opt/boxen/homebrew/lib/libgdal.dylib
+    django-admin.py test elasticsearch_tests --settings=elasticsearch_settings
 
 Configuring Solr
 ================

--- a/docs/running_tests.rst
+++ b/docs/running_tests.rst
@@ -41,14 +41,6 @@ list of possible options::
 
 .. _nose: https://nose.readthedocs.org/en/latest/
 
-Or, to run the Elasticsearch backend's tests::
-
-    cd django-haystack/tests
-    export PYTHONPATH=`pwd`/..:`pwd`
-    export GEOS_LIBRARY_PATH=/opt/boxen/homebrew/lib/libgeos_c.dylib
-    export GDAL_LIBRARY_PATH=/opt/boxen/homebrew/lib/libgdal.dylib
-    django-admin.py test elasticsearch_tests --settings=elasticsearch_settings
-
 Configuring Solr
 ================
 

--- a/docs/running_tests.rst
+++ b/docs/running_tests.rst
@@ -61,3 +61,11 @@ server is found all elasticsearch tests will be skipped. Note that the tests
 are destructive - during the teardown phase they will wipe the cluster clean so
 make sure you don't run them against an instance with data you wish to keep.
 
+If you want to run the geo-django tests you'll probably need some additional
+settings, just run those commands with your own lib paths::
+
+	cd django-haystack/tests
+	export PYTHONPATH=`pwd`/..:`pwd`
+	export GEOS_LIBRARY_PATH=/opt/boxen/homebrew/lib/libgeos_c.dylib
+	export GDAL_LIBRARY_PATH=/opt/boxen/homebrew/lib/libgdal.dylib
+	./run_tests.py elasticsearch_tests

--- a/docs/running_tests.rst
+++ b/docs/running_tests.rst
@@ -61,11 +61,10 @@ server is found all elasticsearch tests will be skipped. Note that the tests
 are destructive - during the teardown phase they will wipe the cluster clean so
 make sure you don't run them against an instance with data you wish to keep.
 
-If you want to run the geo-django tests you'll probably need some additional
-settings, just run those commands with your own lib paths::
+If you want to run the geo-django tests you'll probably need
+`some additional settings`_, then run those commands::
 
-	cd django-haystack/tests
-	export PYTHONPATH=`pwd`/..:`pwd`
-	export GEOS_LIBRARY_PATH=/opt/boxen/homebrew/lib/libgeos_c.dylib
-	export GDAL_LIBRARY_PATH=/opt/boxen/homebrew/lib/libgdal.dylib
+	cd test_haystack
 	./run_tests.py elasticsearch_tests
+
+.. _some additional settings: https://docs.djangoproject.com/en/1.7/ref/contrib/gis/install/geolibs/#geos-library-path

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -444,7 +444,7 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
             # NB: the 1.0.0 release of elasticsearch introduce an
             #     incompatible change on the distance filter formating
             if elasticsearch.VERSION >= (1, 0, 0):
-                distance = "%(dist)f%(unit)s" % {
+                distance = "%(dist).6f%(unit)s" % {
                         'dist': dwithin['distance'].km,
                         'unit': "km"
                     }

--- a/haystack/backends/elasticsearch_backend.py
+++ b/haystack/backends/elasticsearch_backend.py
@@ -440,9 +440,20 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 
         if dwithin is not None:
             lng, lat = dwithin['point'].get_coords()
+
+            # NB: the 1.0.0 release of elasticsearch introduce an
+            #     incompatible change on the distance filter formating
+            if elasticsearch.VERSION >= (1, 0, 0):
+                distance = "%(dist)f%(unit)s" % {
+                        'dist': dwithin['distance'].km,
+                        'unit': "km"
+                    }
+            else:
+                distance = dwithin['distance'].km
+
             dwithin_filter = {
                 "geo_distance": {
-                    "distance": dwithin['distance'].km,
+                    "distance": distance,
                     dwithin['field']: {
                         "lat": lat,
                         "lon": lng

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -1,9 +1,11 @@
 import datetime
+import elasticsearch
 from django.test import TestCase
 from haystack import connections
 from haystack.inputs import Exact
 from haystack.models import SearchResult
 from haystack.query import SQ
+from haystack.utils.geo import Point, D
 from ..core.models import MockModel, AnotherMockModel
 
 
@@ -139,3 +141,48 @@ class ElasticsearchSearchQueryTestCase(TestCase):
         self.sq.add_filter(SQ(content='why'))
         self.sq.add_filter(SQ(title__in=MockModel.objects.values_list('id', flat=True)))
         self.assertEqual(self.sq.build_query(), u'((why) AND title:("1" OR "2" OR "3"))')
+
+
+class ElasticsearchSearchQuerySpatialBeforeReleaseTestCase(TestCase):
+    def setUp(self):
+        super(ElasticsearchSearchQuerySpatialBeforeReleaseTestCase, self).setUp()
+        self.backend = connections['default'].get_backend()
+        self._elasticsearch_version = elasticsearch.VERSION
+        elasticsearch.VERSION = (0,9,9)
+
+    def tearDown(self):
+        elasticsearch.VERSION = self._elasticsearch_version
+
+    def test_build_query_with_dwithin_range(self):
+        """
+        Test build_search_kwargs with dwithin range for Elasticsearch versions < 1.0.0
+        """
+        search_kwargs = self.backend.build_search_kwargs('where', dwithin={
+            'field': "location_field",
+            'point': Point(1.2345678, 2.3456789),
+            'distance': D(m=500)
+        })
+        self.assertEqual(search_kwargs['query']['filtered']['filter']['geo_distance'], {'distance': 0.5, 'location_field': {'lat': 2.3456789, 'lon': 1.2345678}})
+
+
+
+class ElasticsearchSearchQuerySpatialAfterReleaseTestCase(TestCase):
+    def setUp(self):
+        super(ElasticsearchSearchQuerySpatialAfterReleaseTestCase, self).setUp()
+        self.backend = connections['default'].get_backend()
+        self._elasticsearch_version = elasticsearch.VERSION
+        elasticsearch.VERSION = (1,0,0)
+
+    def tearDown(self):
+        elasticsearch.VERSION = self._elasticsearch_version
+
+    def test_build_query_with_dwithin_range(self):
+        """
+        Test build_search_kwargs with dwithin range for Elasticsearch versions >= 1.0.0
+        """
+        search_kwargs = self.backend.build_search_kwargs('where', dwithin={
+            'field': "location_field",
+            'point': Point(1.2345678, 2.3456789),
+            'distance': D(m=500)
+        })
+        self.assertEqual(search_kwargs['query']['filtered']['filter']['geo_distance'], {'distance': "0.500000km", 'location_field': {'lat': 2.3456789, 'lon': 1.2345678}})

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -162,7 +162,7 @@ class ElasticsearchSearchQuerySpatialBeforeReleaseTestCase(TestCase):
             'point': Point(1.2345678, 2.3456789),
             'distance': D(m=500)
         })
-        self.assertEqual(search_kwargs['query']['filtered']['filter']['geo_distance'], {'distance': 0.5, 'location_field': {'lat': 2.3456789, 'lon': 1.2345678}})
+        self.assertEqual(search_kwargs['query']['filtered']['filter']['bool']['must'][1]['geo_distance'], {'distance': 0.5, 'location_field': {'lat': 2.3456789, 'lon': 1.2345678}})
 
 
 
@@ -185,4 +185,4 @@ class ElasticsearchSearchQuerySpatialAfterReleaseTestCase(TestCase):
             'point': Point(1.2345678, 2.3456789),
             'distance': D(m=500)
         })
-        self.assertEqual(search_kwargs['query']['filtered']['filter']['geo_distance'], {'distance': "0.500000km", 'location_field': {'lat': 2.3456789, 'lon': 1.2345678}})
+        self.assertEqual(search_kwargs['query']['filtered']['filter']['bool']['must'][1]['geo_distance'], {'distance': "0.500000km", 'location_field': {'lat': 2.3456789, 'lon': 1.2345678}})

--- a/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
+++ b/test_haystack/elasticsearch_tests/test_elasticsearch_query.py
@@ -146,7 +146,7 @@ class ElasticsearchSearchQueryTestCase(TestCase):
 class ElasticsearchSearchQuerySpatialBeforeReleaseTestCase(TestCase):
     def setUp(self):
         super(ElasticsearchSearchQuerySpatialBeforeReleaseTestCase, self).setUp()
-        self.backend = connections['default'].get_backend()
+        self.backend = connections['elasticsearch'].get_backend()
         self._elasticsearch_version = elasticsearch.VERSION
         elasticsearch.VERSION = (0,9,9)
 
@@ -169,7 +169,7 @@ class ElasticsearchSearchQuerySpatialBeforeReleaseTestCase(TestCase):
 class ElasticsearchSearchQuerySpatialAfterReleaseTestCase(TestCase):
     def setUp(self):
         super(ElasticsearchSearchQuerySpatialAfterReleaseTestCase, self).setUp()
-        self.backend = connections['default'].get_backend()
+        self.backend = connections['elasticsearch'].get_backend()
         self._elasticsearch_version = elasticsearch.VERSION
         elasticsearch.VERSION = (1,0,0)
 

--- a/test_haystack/settings.py
+++ b/test_haystack/settings.py
@@ -73,3 +73,6 @@ MIDDLEWARE_CLASSES = ('django.middleware.common.CommonMiddleware',
                       'django.middleware.csrf.CsrfViewMiddleware',
                       'django.contrib.auth.middleware.AuthenticationMiddleware',
                       'django.contrib.messages.middleware.MessageMiddleware')
+
+GEOS_LIBRARY_PATH = os.environ.get('GEOS_LIBRARY_PATH', '')
+GDAL_LIBRARY_PATH = os.environ.get('GDAL_LIBRARY_PATH', '')


### PR DESCRIPTION
There were some *major* changes in the 1.0 release of Elasticsearch that break compatibility with haystack.
This PR is there to repair that :cake:

Cheers

Fix #957
Fix #998
Fix #984 