### PR TITLE
Adds a --nocommit arg to the update_index, clear_index and rebuild_index management command.

### DIFF
--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -23,9 +23,17 @@ following arguments::
     ``--using``:
         If provided, determines which connection should be used. Default is
         ``default``.
+    ``--nocommit``:
+        If provided, it will pass commit=False to the backend.  This means that the
+        update will not become immediately visible and will depend on another explicit commit
+        or the backend's commit strategy to complete the update.
 
 By default, this is an **INTERACTIVE** command and assumes that you do **NOT**
 wish to delete the entire index.
+
+.. note::
+
+    The ``--nocommit`` argument is only supported by the Solr backend.
 
 .. warning::
 
@@ -80,6 +88,14 @@ arguments::
     ``--using``:
         If provided, determines which connection should be used. Default is
         ``default``.
+    ``--nocommit``:
+        If provided, it will pass commit=False to the backend.  This means that the
+        updates will not become immediately visible and will depend on another explicit commit
+        or the backend's commit strategy to complete the update.
+
+.. note::
+
+    The ``--nocommit`` argument is only supported by the Solr and Elasticsearch backends.
 
 Examples::
 
@@ -147,6 +163,10 @@ of the arguments of the following arguments::
     ``--using``:
         If provided, determines which connection should be used. Default is
         ``default``.
+    ``--nocommit``:
+        If provided, it will pass commit=False to the backend.  This means that the
+        update will not become immediately visible and will depend on another explicit commit
+        or the backend's commit strategy to complete the update.
 
 For when you really, really want a completely rebuilt index.
 

--- a/haystack/backends/solr_backend.py
+++ b/haystack/backends/solr_backend.py
@@ -103,8 +103,9 @@ class SolrSearchBackend(BaseSearchBackend):
 
                 self.conn.delete(q=" OR ".join(models_to_delete), commit=commit)
 
-            # Run an optimize post-clear. http://wiki.apache.org/solr/FAQ#head-9aafb5d8dff5308e8ea4fcf4b71f19f029c4bb99
-            self.conn.optimize()
+            if commit:
+                # Run an optimize post-clear. http://wiki.apache.org/solr/FAQ#head-9aafb5d8dff5308e8ea4fcf4b71f19f029c4bb99
+                self.conn.optimize()
         except (IOError, SolrError) as e:
             if not self.silently_fail:
                 raise

--- a/haystack/management/commands/clear_index.py
+++ b/haystack/management/commands/clear_index.py
@@ -18,6 +18,9 @@ class Command(BaseCommand):
             help='Update only the named backend (can be used multiple times). '
                  'By default all backends will be updated.'
         ),
+        make_option('--nocommit', action='store_false', dest='commit',
+            default=True, help='Will pass commit=False to the backend.'
+        ),
     )
     option_list = BaseCommand.option_list + base_options
 
@@ -25,6 +28,7 @@ class Command(BaseCommand):
         """Clears out the search index completely."""
         from haystack import connections
         self.verbosity = int(options.get('verbosity', 1))
+        self.commit = options.get('commit', True)
 
         using = options.get('using')
         if not using:
@@ -47,7 +51,7 @@ class Command(BaseCommand):
 
         for backend_name in using:
             backend = connections[backend_name].get_backend()
-            backend.clear()
+            backend.clear(commit=self.commit)
 
         if self.verbosity >= 1:
             print("All documents removed.")


### PR DESCRIPTION
This is helpful when doing bulk indexing and you'd rather have the backend handle commits, not the management command.  We had an instance where the amount of hard commits passed by update_index during a bulk index was causing stability issues with our solr cluster that was already doing soft and hard commits often.

I attempted to add this flag to clear_index and the --remove option of update_index, but it seems that solr was not respecting commit=false for those two code paths.  I can look into it some more, but wasn't able to find a solution.